### PR TITLE
Host/timestamp parsing fix for RFC3164 messages.

### DIFF
--- a/lib/glossy/parse.js
+++ b/lib/glossy/parse.js
@@ -169,6 +169,7 @@ function parseMessage(rawMessage, callback) {
 
     } else if(segments[0].match(/^(<\d+>\w+)/)) {
         parsedMessage.type    = 'RFC3164';
+        if (segments[1] == '') segments.splice(1,1); 
         var timeStamp         = segments.splice(0,3).join(' ').replace(/^(<\d+>)/,'');
         parsedMessage.time    = parseTimeStamp(timeStamp);
         parsedMessage.host    = segments.shift();

--- a/test/parse.js
+++ b/test/parse.js
@@ -41,3 +41,7 @@ syslogParser.parse(messages[1], function(secondParsed){
     assert.equal(secondParsed.host, 'mymachine.example.com', 'hostname matches');
 });
 
+syslogParser.parse(messages[4], function(rfc3164_before_10th){
+    assert.ok(rfc3164_before_10th, 'RFC 3164 record parsed.');
+    assert.equal(rfc3164_before_10th.host, '10.0.0.99');
+});


### PR DESCRIPTION
For RFC3164 messages the first 9 days of each month cause an extra space to appear between the month code and the day of the month. This fix checks to see if the extra space exists and removes it if it does.
