### PR TITLE
RFC-3164 dates have leading zero before date when date has only one digit

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -197,7 +197,13 @@ GlossyProducer.prototype.produce = function(options, callback) {
         }
     }
 
-    var compiledMessage = msgData.join(' ').replace(/\s+/g, ' ');
+    var compiledMessage = msgData.filter(function (messageElement) {
+        // Filter null/ undefined values
+        return messageElement;
+    }).map(function (messageElement) {
+        // Trim messages to remove successive whitespace
+        return messageElement.trim();
+    }).join(' ');
     compiledMessage += ' ' + options.message || '';
     msgData.push(compiledMessage);
 

--- a/test/produce.js
+++ b/test/produce.js
@@ -150,3 +150,12 @@ var structuredMsg = syslogProducer.produce({
 
 assert.ok(structuredMsg);
 assert.equal(structuredMsg, '<163>1 2009-02-13T23:31:30.00Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] BOMAn application event log entry...');
+
+var messageWithOneDigitDate = presetProducer.emergency({
+    facility: 'news',
+    message: 'Emergency Message',
+    pid: 91,
+    date: new Date(1233531090000)
+});
+assert.ok(messageWithOneDigitDate);
+assert.equal(messageWithOneDigitDate, '<56>Feb  1 23:31:30 localhost kill[91]: Emergency Message');


### PR DESCRIPTION
Hi,

when using glossy to produce RFC-3164 messages and the day of month only has one digit, the resulting timestamp did not have a leading space before the date (as defined in the RFC). This was due to the replace whitespace statement.

I fixed this issue by filtering and trimming the message parts prior to joining them. I also added a test case to test/produce.js.

Best,
Alex
