### PR TITLE
Fixes upstream #16

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -2,7 +2,7 @@
  *    Glossy Producer - Generate valid syslog messages
  *
  *    Copyright Squeeks <privacymyass@gmail.com>.
- *    This is free software licensed under the MIT License - 
+ *    This is free software licensed under the MIT License -
  *    see the LICENSE file that should be included with this package.
  */
 
@@ -38,7 +38,7 @@ var FacilityIndex = {
 
 // Note 1 - Various operating systems have been found to utilize
 //           Facilities 4, 10, 13 and 14 for security/authorization,
-//           audit, and alert messages which seem to be similar. 
+//           audit, and alert messages which seem to be similar.
 
 // Note 2 - Various operating systems have been found to utilize
 //           both Facilities 9 and 15 for clock (cron/at) messages.
@@ -129,7 +129,7 @@ var GlossyProducer = function(options) {
  *      facility: The facility index
  *      severity: Severity index
  *      prival: RFC5424 PRIVAL field - will override facility/severity if in valid [0-191] range and both provided
- *         see ABNF at: (http://tools.ietf.org/html/rfc5424#section-6) 
+ *         see ABNF at: (http://tools.ietf.org/html/rfc5424#section-6)
  *      host: Host address, either name or IP
  *      appName: Application ID
  *      pid: Process ID
@@ -148,9 +148,9 @@ GlossyProducer.prototype.produce = function(options, callback) {
 
     var msgData = [];
     if(!options.date instanceof Date) {
-        options.date = new Date(Date());
+        options.date = new Date();
     }
-    
+
     if(!options.facility) options.facility = this.facility;
 
     if(this.type == 'RFC5424') {
@@ -158,7 +158,7 @@ GlossyProducer.prototype.produce = function(options, callback) {
           var prival = '<' + options.prival + '>1';
         }
         else {
-          var prival = calculatePrival({ 
+          var prival = calculatePrival({
             facility: options.facility,
             severity: options.severity,
             version:  1
@@ -183,9 +183,9 @@ GlossyProducer.prototype.produce = function(options, callback) {
         if(!options.message) options.message = '-';
 
     } else {
-        options.timestamp = generateBSDDate(options.date);    
+        options.timestamp = generateBSDDate(options.date);
         msgData.push(
-            calculatePrival({ 
+            calculatePrival({
                 facility: options.facility,
                 severity: options.severity
             }) + options.timestamp
@@ -331,7 +331,7 @@ function leadZero(n) {
  *  Features code taken from https://github.com/akaspin/ain
  */
 function generateBSDDate(dateObject) {
-    if(!(dateObject instanceof Date)) dateObject = new Date(Date());
+    if(!(dateObject instanceof Date)) dateObject = new Date();
     var hours   = leadZero(dateObject.getHours());
     var minutes = leadZero(dateObject.getMinutes());
     var seconds = leadZero(dateObject.getSeconds());
@@ -349,31 +349,9 @@ function generateBSDDate(dateObject) {
  *  @returns {String} formatted date
  */
 function generateDate(dateObject) {
-    if(!(dateObject instanceof Date)) dateObject = new Date(Date());
-    
-    // Calcutate the offset
-    var timeOffset;
-    var minutes = Math.abs(dateObject.getTimezoneOffset());
-    var hours = 0;
-    while(minutes >= 60) {
-        hours++;
-        minutes -= 60;
-    }
-
-    if(dateObject.getTimezoneOffset() < 0) {
-        // Ahead of UTC
-        timeOffset = '+' + leadZero(hours) + '' + ':' + leadZero(minutes);
-    } else if(dateObject.getTimezoneOffset() > 0) {
-        // Behind UTC
-        timeOffset = '-' + leadZero(hours) + '' + ':' + leadZero(minutes);
-    } else {
-        // UTC
-        timeOffset = 'Z';
-    }
-
-
+    if(!(dateObject instanceof Date)) dateObject = new Date();
     // Date
-    formattedDate = dateObject.getUTCFullYear()         + '-' +
+    return dateObject.getUTCFullYear()         + '-' +
     // N.B. Javascript Date objects return months of the year indexed from
     // zero, while the RFC 5424 syslog standard expects months indexed from
     // one.
@@ -385,11 +363,7 @@ function generateDate(dateObject) {
     leadZero(dateObject.getUTCHours())         + ':' +
     leadZero(dateObject.getUTCMinutes())       + ':' +
     leadZero(dateObject.getUTCSeconds())       + '.' +
-    leadZero(dateObject.getUTCMilliseconds())  +
-    timeOffset;
-    
-    return formattedDate;
-    
+    leadZero(dateObject.getUTCMilliseconds())  + 'Z';
 }
 
 
@@ -439,7 +413,7 @@ function generateStructuredData(struct) {
     if(typeof struct != 'object') return false;
 
     var structuredData = '';
-    
+
     for(var sdID in struct) {
         sdElement = struct[sdID];
         structuredData += '[' + sdID;


### PR DESCRIPTION
Dump all the timezone stuff in `generateDate()` as the string is built in UTC so just append `'Z'` and it will parse properly on the other end (tested by looping back into `Parser.parse()`)

`new Date(Date())` is terribly redundant under Node and/or V8 in general, stripped all usages
editor auto cleaned some wasted white space