### PR TITLE
Explicit string coercion for safe trimming

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -210,7 +210,7 @@ GlossyProducer.prototype.produce = function(options, callback) {
         return messageElement;
     }).map(function (messageElement) {
         // Trim messages to remove successive whitespace
-        return messageElement.trim();
+        return String(messageElement).trim();
     }).join(' ');
     compiledMessage += ' ' + options.message || '';
     msgData.push(compiledMessage);


### PR DESCRIPTION
Next code throws  "TypeError: messageElement.trim is not a function" error for me. But if type is 'bsd' then msg will be "<163>Nov 16 21:02:05 localhost sudo[123]: Nice, Neat, New, Oh Wow". 

Actually, process pid is almost always an integer, not a string.

``` javascript
var syslogProducer = new GlossyProducer({type:'RFC5424'}); // or wherever glossy lives

var msg = syslogProducer.produce({
    facility: 'local4', // these can either be a valid integer, 
    severity: 'error',  // or a relevant string
    host: 'localhost',
    appName: 'sudo',
    pid: 123,
    date: new Date(Date()),
    message: 'Nice, Neat, New, Oh Wow'
});
console.log(msg);
```
