### PR TITLE
Add new type 'socket'

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -103,10 +103,16 @@ var BSDDateIndex = [
  *  @return {Object} GlossyProducer object
  */
 var GlossyProducer = function(options) {
+    var type;
     if(options && typeof options =='object' && options.type) {
-        this.type = options.type.match(/bsd|3164/i) ? "RFC3164" : "RFC5424";
+        type = options.type;
     } else if(options && typeof options == 'string') {
-        this.type = options.match(/bsd|3164/i) ? "RFC3164" : "RFC5424";
+        type = options;
+    }
+    if(type.match(/bsd|3164/i)) {
+        this.type = "RFC3164";
+    } else if(type.match(/socket/i)) {
+        this.type = "socket";
     } else {
         this.type = "RFC5424";
     }
@@ -191,8 +197,10 @@ GlossyProducer.prototype.produce = function(options, callback) {
             }) + options.timestamp
         );
 
-        msgData.push(options.host || this.host);
-        msgData.push();
+        if(this.type !== 'socket') {
+            msgData.push(options.host || this.host);
+            msgData.push();
+        }
         if(options.appName || this.appName) {
             var app = options.appName || this.appName;
             var pid = options.pid     || this.pid;


### PR DESCRIPTION
The syslog format for the /dev/log socket does not include a hostname
field, thus create a new type named 'socket'.