### PR TITLE
Fix RFC 3339 date offset handling

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -352,7 +352,7 @@ function generateDate(dateObject) {
     if(!(dateObject instanceof Date)) dateObject = new Date(Date());
     
     // set the offset to UCT
-    timeOffset = 'Z';
+    var timeOffset = 'Z';
 
     // Date
     formattedDate = dateObject.getUTCFullYear()         + '-' +

--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -351,26 +351,8 @@ function generateBSDDate(dateObject) {
 function generateDate(dateObject) {
     if(!(dateObject instanceof Date)) dateObject = new Date(Date());
     
-    // Calcutate the offset
-    var timeOffset;
-    var minutes = Math.abs(dateObject.getTimezoneOffset());
-    var hours = 0;
-    while(minutes >= 60) {
-        hours++;
-        minutes -= 60;
-    }
-
-    if(dateObject.getTimezoneOffset() < 0) {
-        // Ahead of UTC
-        timeOffset = '+' + leadZero(hours) + '' + ':' + leadZero(minutes);
-    } else if(dateObject.getTimezoneOffset() > 0) {
-        // Behind UTC
-        timeOffset = '-' + leadZero(hours) + '' + ':' + leadZero(minutes);
-    } else {
-        // UTC
-        timeOffset = 'Z';
-    }
-
+    // set the offset to UCT
+    timeOffset = 'Z';
 
     // Date
     formattedDate = dateObject.getUTCFullYear()         + '-' +

--- a/test/produce.js
+++ b/test/produce.js
@@ -33,7 +33,7 @@ var msg = syslogProducer.produce({
     date: new Date(1234567890000),
     message: 'Test Message'
 });
-assert.equal(msg, "<163>1 2009-02-13T23:31:30.00+01:00 localhost sudo 123 - - Test Message",'Valid message returned');
+assert.equal(msg, "<163>1 2009-02-13T23:31:30.00Z localhost sudo 123 - - Test Message",'Valid message returned');
 
 syslogProducer.produce({
     facility: 'audit',
@@ -44,7 +44,7 @@ syslogProducer.produce({
     date: new Date(1234567890000),
     message: 'Test Message'
 }, function(cbMsg) {
-    assert.equal(cbMsg, '<107>1 2009-02-13T23:31:30.00+01:00 127.0.0.1 sudo 419 - - Test Message', 'Valid message in callback returned');
+    assert.equal(cbMsg, '<107>1 2009-02-13T23:31:30.00Z 127.0.0.1 sudo 419 - - Test Message', 'Valid message in callback returned');
 });
 
 BSDProducer.produce({
@@ -150,7 +150,7 @@ var structuredMsg = syslogProducer.produce({
 });
 
 assert.ok(structuredMsg);
-assert.equal(structuredMsg, '<163>1 2009-02-13T23:31:30.00+01:00 mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011" seqNo="1"] BOMAn application event log entry...');
+assert.equal(structuredMsg, '<163>1 2009-02-13T23:31:30.00Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011" seqNo="1"] BOMAn application event log entry...');
 
 var structuredWithArray = syslogProducer.produce({
     facility: 'local4',
@@ -168,7 +168,7 @@ var structuredWithArray = syslogProducer.produce({
 });
 
 assert.ok(structuredWithArray);
-assert.equal(structuredWithArray, '<163>1 2009-02-13T23:31:30.00+01:00 mymachine.example.com evntslog - ID47 [origin ip="127.0.1.1" ip="127.0.0.1"] BOMAn application event log entry...');
+assert.equal(structuredWithArray, '<163>1 2009-02-13T23:31:30.00Z mymachine.example.com evntslog - ID47 [origin ip="127.0.1.1" ip="127.0.0.1"] BOMAn application event log entry...');
 
 var messageWithOneDigitDate = presetProducer.emergency({
     facility: 'news',


### PR DESCRIPTION
UTC date and time components were being used but a time offset was also being calculated. Either a time offset of UTC should be used or the date and time should take the offset into account. I chose to implement the former option as it is easier, however, it could go either way.