### PR TITLE
Fix RFC 3339 date handling

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -373,19 +373,19 @@ function generateDate(dateObject) {
 
 
     // Date
-    formattedDate = dateObject.getUTCFullYear()         + '-' +
+    formattedDate = dateObject.getFullYear()         + '-' +
     // N.B. Javascript Date objects return months of the year indexed from
     // zero, while the RFC 5424 syslog standard expects months indexed from
     // one.
-    leadZero(dateObject.getUTCMonth() + 1)  + '-' +
+    leadZero(dateObject.getMonth() + 1)  + '-' +
     // N.B. Javascript Date objects return days of the month indexed from one
     // (unlike months of year), so this does not need any correction.
-    leadZero(dateObject.getUTCDate())   + 'T' +
+    leadZero(dateObject.getDate())   + 'T' +
     // Time
-    leadZero(dateObject.getUTCHours())         + ':' +
-    leadZero(dateObject.getUTCMinutes())       + ':' +
-    leadZero(dateObject.getUTCSeconds())       + '.' +
-    leadZero(dateObject.getUTCMilliseconds())  +
+    leadZero(dateObject.getHours())         + ':' +
+    leadZero(dateObject.getMinutes())       + ':' +
+    leadZero(dateObject.getSeconds())       + '.' +
+    leadZero(dateObject.getMilliseconds())  +
     timeOffset;
     
     return formattedDate;

--- a/test/produce.js
+++ b/test/produce.js
@@ -33,7 +33,7 @@ var msg = syslogProducer.produce({
     date: new Date(1234567890000),
     message: 'Test Message'
 });
-assert.equal(msg, "<163>1 2009-02-13T23:31:30.00+01:00 localhost sudo 123 - - Test Message",'Valid message returned');
+assert.equal(msg, "<163>1 2009-02-14T00:31:30.00+01:00 localhost sudo 123 - - Test Message",'Valid message returned');
 
 syslogProducer.produce({
     facility: 'audit',
@@ -44,7 +44,7 @@ syslogProducer.produce({
     date: new Date(1234567890000),
     message: 'Test Message'
 }, function(cbMsg) {
-    assert.equal(cbMsg, '<107>1 2009-02-13T23:31:30.00+01:00 127.0.0.1 sudo 419 - - Test Message', 'Valid message in callback returned');
+    assert.equal(cbMsg, '<107>1 2009-02-14T00:31:30.00+01:00 127.0.0.1 sudo 419 - - Test Message', 'Valid message in callback returned');
 });
 
 BSDProducer.produce({
@@ -150,7 +150,7 @@ var structuredMsg = syslogProducer.produce({
 });
 
 assert.ok(structuredMsg);
-assert.equal(structuredMsg, '<163>1 2009-02-13T23:31:30.00+01:00 mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011" seqNo="1"] BOMAn application event log entry...');
+assert.equal(structuredMsg, '<163>1 2009-02-14T00:31:30.00+01:00 mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011" seqNo="1"] BOMAn application event log entry...');
 
 var structuredWithArray = syslogProducer.produce({
     facility: 'local4',
@@ -168,7 +168,7 @@ var structuredWithArray = syslogProducer.produce({
 });
 
 assert.ok(structuredWithArray);
-assert.equal(structuredWithArray, '<163>1 2009-02-13T23:31:30.00+01:00 mymachine.example.com evntslog - ID47 [origin ip="127.0.1.1" ip="127.0.0.1"] BOMAn application event log entry...');
+assert.equal(structuredWithArray, '<163>1 2009-02-14T00:31:30.00+01:00 mymachine.example.com evntslog - ID47 [origin ip="127.0.1.1" ip="127.0.0.1"] BOMAn application event log entry...');
 
 var messageWithOneDigitDate = presetProducer.emergency({
     facility: 'news',


### PR DESCRIPTION
Glossy was mixing a time offset with UTC dates when producing syslog messages. This change fixes this so that time offsets are used properly.

Original discussion around this can be found here: #33
