### PR TITLE
fixes kernel facility issue

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -111,7 +111,7 @@ var GlossyProducer = function(options) {
         this.type = "RFC5424";
     }
 
-    if(options && options.facility && FacilityIndex[options.facility]) {
+    if(options && options.facility && (FacilityIndex[options.facility] !== undefined)) {
         this.facility = options.facility;
     }
     if(options && options.pid && parseInt(options.pid, 10)) {


### PR DESCRIPTION
Kernel facility is getting discarded as value for kernel facility is 0. 
This condition turns out to be false -  (options && options.facility && FacilityIndex[options.facility])
which leads the facility to fallback to local0