### PR TITLE
fix: Pad milliseconds with three zeroes

### DIFF
--- a/lib/glossy/produce.js
+++ b/lib/glossy/produce.js
@@ -385,7 +385,7 @@ function generateDate(dateObject) {
     leadZero(dateObject.getHours())         + ':' +
     leadZero(dateObject.getMinutes())       + ':' +
     leadZero(dateObject.getSeconds())       + '.' +
-    leadZero(dateObject.getMilliseconds())  +
+    String(dateObject.getMilliseconds()).padStart(3, '0') +
     timeOffset;
     
     return formattedDate;


### PR DESCRIPTION
Hi!

Currently milliseconds are padded only with two zeroes, e.g.

```
<131>1 2021-09-27T15:52:35.35-07:00 localhost test-graylog-syslog 103065 - - error: Test message
```

Unfortunately Graylog parses `15:52:35.35` as `15:52:35.350` instead of `15:52:35.035`, so this fixes that.

Also if this package could be published as a new version on NPM that would be great, since it would fix other issues such as #43 :grinning: 

Thanks!